### PR TITLE
Refactor category emojis & Fix Job Categories layout

### DIFF
--- a/components/categories-drawer.jsx
+++ b/components/categories-drawer.jsx
@@ -23,30 +23,12 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { FiArrowLeft as BackIcon } from 'react-icons/fi'
-import ContentEmoji from './icons/categories/content.svg'
-import DesignEmoji from './icons/categories/design.svg'
-import ManagementEmoji from './icons/categories/management.svg'
-import MarketingEmoji from './icons/categories/marketing.svg'
-import SalesEmoji from './icons/categories/sales.svg'
-import SupportEmoji from './icons/categories/support.svg'
-import TechEmoji from './icons/categories/tech.svg'
-import OthersEmoji from './icons/categories/others.svg'
+import CategoryEmoji from './category-emoji'
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { useRoles } from 'contexts/roles-context'
 import { useSelectedCategories } from 'contexts/selected-categories-context'
 import { useSelectedRoles } from 'contexts/selected-roles-context'
-
-const categoryEmojis = {
-  Content: ContentEmoji,
-  Design: DesignEmoji,
-  Management: ManagementEmoji,
-  Marketing: MarketingEmoji,
-  Sales: SalesEmoji,
-  Support: SupportEmoji,
-  Tech: TechEmoji,
-  Others: OthersEmoji,
-}
 
 const AddFiltersButton = ({ isOpen, onOpen, categories }) => {
   const [selectedCategories, setSelectedCategories] = useSelectedCategories()
@@ -153,7 +135,7 @@ const CateoriesTabs = ({
             category.roles.length === selectedRolesInThisCategory.length
               ? 'All'
               : selectedRolesInThisCategory.length
-          const CategoryEmoji = categoryEmojis[category.category]
+
           return (
             <Tab
               justifyContent="flex-start"
@@ -163,7 +145,7 @@ const CateoriesTabs = ({
               key={index}
             >
               <HStack>
-                <CategoryEmoji />
+                <CategoryEmoji categoryName={category.category} />
                 <Text>{category.category}</Text>
                 {selectedRolesInThisCategory.length > 0 && (
                   <Badge

--- a/components/category-emoji.jsx
+++ b/components/category-emoji.jsx
@@ -1,0 +1,24 @@
+import ContentEmoji from './icons/categories/content.svg'
+import DesignEmoji from './icons/categories/design.svg'
+import ManagementEmoji from './icons/categories/management.svg'
+import MarketingEmoji from './icons/categories/marketing.svg'
+import SalesEmoji from './icons/categories/sales.svg'
+import SupportEmoji from './icons/categories/support.svg'
+import TechEmoji from './icons/categories/tech.svg'
+import OthersEmoji from './icons/categories/others.svg'
+
+export default ({ categoryName }) => {
+  const categoryEmojis = {
+    Content: ContentEmoji,
+    Design: DesignEmoji,
+    Management: ManagementEmoji,
+    Marketing: MarketingEmoji,
+    Sales: SalesEmoji,
+    Support: SupportEmoji,
+    Tech: TechEmoji,
+    Others: OthersEmoji,
+  }
+
+  const CategoryEmoji = categoryEmojis[categoryName]
+  return <CategoryEmoji />
+}

--- a/components/job-categories.jsx
+++ b/components/job-categories.jsx
@@ -12,14 +12,7 @@ import {
 } from '@chakra-ui/react'
 
 import { FiRefreshCcw } from 'react-icons/fi'
-import ContentEmoji from './icons/categories/content.svg'
-import DesignEmoji from './icons/categories/design.svg'
-import ManagementEmoji from './icons/categories/management.svg'
-import MarketingEmoji from './icons/categories/marketing.svg'
-import SalesEmoji from './icons/categories/sales.svg'
-import SupportEmoji from './icons/categories/support.svg'
-import TechEmoji from './icons/categories/tech.svg'
-import OthersEmoji from './icons/categories/others.svg'
+import CategoryEmoji from './category-emoji'
 
 import Container from './container'
 import { useModal } from 'contexts/modal-context'
@@ -30,7 +23,7 @@ import { useOpenedCategory } from 'contexts/opened-category-context'
 import { useSelectedCategories } from 'contexts/selected-categories-context'
 import { useSelectedRoles } from 'contexts/selected-roles-context'
 
-const Category = ({ icon, category, start, end }) => {
+const Category = ({ category, start, end }) => {
   const { onOpen } = useModal()
   const [roles, setRoles] = useRoles()
   const [openedCategory, setOpenedCategory] = useOpenedCategory()
@@ -74,7 +67,7 @@ const Category = ({ icon, category, start, end }) => {
         _focusVisible={{ borderBottom: '4px solid gray' }}
       >
         <Center w="8" h="10">
-          {icon}
+          <CategoryEmoji categoryName={category.category} />
         </Center>
         <Text ml="2" fontSize="sm" fontWeight="normal" color="gray.600">
           {category.category}
@@ -201,14 +194,9 @@ export default function JobCategories({ categories }) {
           </Button>
         </Flex>
         <HStack mt="5" spacing="0" display={{ base: 'none', md: 'flex' }}>
-          <Category start category={categories[0]} icon={<TechEmoji />} />
-          <Category category={categories[1]} icon={<DesignEmoji />} />
-          <Category category={categories[2]} icon={<ManagementEmoji />} />
-          <Category category={categories[3]} icon={<MarketingEmoji />} />
-          <Category category={categories[4]} icon={<SalesEmoji />} />
-          <Category category={categories[5]} icon={<ContentEmoji />} />
-          <Category category={categories[6]} icon={<SupportEmoji />} />
-          <Category end category={categories[7]} icon={<OthersEmoji />} />
+          {categories.map((category, i) => {
+            return <Category category={categories[i]} />
+          })}
         </HStack>
       </Container>
     </Box>

--- a/components/job-categories.jsx
+++ b/components/job-categories.jsx
@@ -2,7 +2,6 @@ import {
   Badge,
   Box,
   Text,
-  HStack,
   Center,
   Flex,
   Button,
@@ -23,7 +22,7 @@ import { useOpenedCategory } from 'contexts/opened-category-context'
 import { useSelectedCategories } from 'contexts/selected-categories-context'
 import { useSelectedRoles } from 'contexts/selected-roles-context'
 
-const Category = ({ category, start, end }) => {
+const Category = ({ category }) => {
   const { onOpen } = useModal()
   const [roles, setRoles] = useRoles()
   const [openedCategory, setOpenedCategory] = useOpenedCategory()
@@ -47,45 +46,34 @@ const Category = ({ category, start, end }) => {
   }
 
   return (
-    <Box pos="relative">
-      <Button
-        bg="gray.50"
-        py="2"
-        px="8"
-        w="full"
-        height="10"
-        bg="white"
-        borderWidth="1px"
-        borderColor="gray.200"
-        borderRadius="none"
-        _hover={{ bg: 'gray.100' }}
-        borderRightWidth={!end && '0'}
-        borderLeftRadius={start && 'lg'}
-        borderRightRadius={end && 'lg'}
-        onClick={onClickHandler}
-        _focus={{ outline: 'none' }}
-        _focusVisible={{ borderBottom: '4px solid gray' }}
-      >
-        <Center w="8" h="10">
-          <CategoryEmoji categoryName={category.category} />
-        </Center>
-        <Text ml="2" fontSize="sm" fontWeight="normal" color="gray.600">
-          {category.category}
-        </Text>
-        {(selectedRolesInThisCategory.length > 0 ||
-          selectedCategories.includes(category.category)) && (
-          <Badge
-            ml="2"
-            variant="solid"
-            colorScheme="blue"
-            borderRadius="full"
-            fontSize="0.8em"
-          >
-            {selectedRolesInThisCategoryCountText}
-          </Badge>
-        )}
-      </Button>
-    </Box>
+    <Button
+      bg="white"
+      borderRadius="0"
+      flex="1"
+      _hover={{ bg: '#F6F6F6' }}
+      _focus={{ outline: 'none' }}
+      _focusVisible={{ borderBottom: '4px solid', borderColor: 'blue.500' }}
+      onClick={onClickHandler}
+    >
+      <Center w="8" h="10">
+        <CategoryEmoji categoryName={category.category} />
+      </Center>
+      <Text ml="2" fontSize="sm" fontWeight="normal" color="gray.600">
+        {category.category}
+      </Text>
+      {(selectedRolesInThisCategory.length > 0 ||
+        selectedCategories.includes(category.category)) && (
+        <Badge
+          ml="2"
+          variant="solid"
+          colorScheme="blue"
+          borderRadius="full"
+          fontSize="0.8em"
+        >
+          {selectedRolesInThisCategoryCountText}
+        </Badge>
+      )}
+    </Button>
   )
 }
 
@@ -193,11 +181,19 @@ export default function JobCategories({ categories }) {
             Reset filters
           </Button>
         </Flex>
-        <HStack mt="5" spacing="0" display={{ base: 'none', md: 'flex' }}>
+        <Flex
+          flexDirection="row"
+          mt="5"
+          display={{ base: 'none', md: 'flex' }}
+          borderWidth="1px"
+          borderColor="gray.200"
+          borderRadius="lg"
+          overflow="hidden"
+        >
           {categories.map((category, i) => {
             return <Category category={categories[i]} />
           })}
-        </HStack>
+        </Flex>
       </Container>
     </Box>
   )


### PR DESCRIPTION
## Chores
Refactored category emojis to a CategoryEmoji component.
```
<CategoryEmoji categoryName="Tech" />
```

## Improvements
After refactoring the category emojis in the job categories component, we had to fix the categories strip layout since the start and end props can't be passed.
That's why I almost revamped the whole component's UI to make it closer to the Figma mockup.
![image](https://user-images.githubusercontent.com/36705914/132102517-ef9c922d-79c8-4dc1-a35e-9e7f5e532611.png)

And it is better with the awkward screen sizes so the issue https://github.com/catoverse/yellowjobs-frontend/issues/16 is kinda fixed now.